### PR TITLE
white-space:pre-wrap

### DIFF
--- a/templates/tag.html
+++ b/templates/tag.html
@@ -15,7 +15,7 @@
   <div style="float: left; margin-left: 30px; max-width: 600px">
     {% for snippet in snippets %}
       <b>{{ snippet.user.pretty_name }}</b><br/>
-      <pre>{{ snippet.text|urlize }}</pre>
+      <pre style="white-space:pre-wrap">{{ snippet.text|urlize }}</pre>
       <br/></br>
     {% endfor %}
    </div>

--- a/templates/user.html
+++ b/templates/user.html
@@ -27,7 +27,7 @@
   <div style="float: left; margin-left: 30px; max-width: 600px">
     {% for snippet in snippets %}
       <b>{{ snippet.date }}</b><br/>
-      <pre>{{ snippet.text|urlize }}</pre>
+      <pre style="white-space:pre-wrap">{{ snippet.text|urlize }}</pre>
       <br/></br>
     {% endfor %}
    </div>


### PR DESCRIPTION
an altogether better option is to convert it into
html (newlines -> br, whitespace -> &nbsp;) so you
can use white-space:normal
